### PR TITLE
Map 113 - Improvement Task for WFS Controller

### DIFF
--- a/cdm/src/main/java/thredds/client/catalog/ServiceType.java
+++ b/cdm/src/main/java/thredds/client/catalog/ServiceType.java
@@ -38,7 +38,7 @@ public enum ServiceType {
           " conforms to the NetCDF Attribute Convention for Data Discovery (NACDD)", AccessType.Metadata),              //
   WebForm,        //    ??
   WCS("Supports access to geospatial data as 'coverages'.", AccessType.DataAccess),                                     //
-  WFS,            //
+  WFS("Supports access to geospatial data as simple geometry objects (such as polygons and lines).", AccessType.DataAccess),            //
   WMS("Supports access to georegistered map images from geoscience datasets.", AccessType.DataAccess),                  //
   WSDL,           //
   ;
@@ -67,7 +67,7 @@ public enum ServiceType {
   public boolean isStandardTdsService() {
     return this == Catalog || this == CdmRemote || this == CdmrFeature || this == DAP4 ||
       this == DODS || this == File || this == HTTPServer || this == ISO || this == NCML ||
-      this == NetcdfSubset || this == OPENDAP || this == UDDC || this == WCS || this == WMS;
+      this == NetcdfSubset || this == OPENDAP || this == UDDC || this == WCS || this == WMS || this == WFS;
   }
 
   public String getDescription() { return this.desc; }

--- a/tds/src/main/java/thredds/core/StandardService.java
+++ b/tds/src/main/java/thredds/core/StandardService.java
@@ -26,6 +26,7 @@ public enum StandardService {
   opendap(ServiceType.OPENDAP, "/dodsC/"),
   wcs(ServiceType.WCS, "/wcs/"),
   wms(ServiceType.WMS, "/wms/"),
+  wfs(ServiceType.WFS, "/wfs/"),
 
   iso(ServiceType.ISO, "/iso/"),
   iso_ncml(ServiceType.NCML, "/ncml/"),

--- a/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
+++ b/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
@@ -474,6 +474,10 @@ class DatasetContext {
             queryString = "service=WMS&version=1.3.0&request=GetCapabilities";
             break;
 
+          case WFS:
+        	queryString = "service=WFS&version=2.0.0&request=GetCapabilities";
+        	break;
+        	 
           case NCML:
           case UDDC:
           case ISO:

--- a/tds/src/main/java/thredds/server/wfs/WFSController.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSController.java
@@ -5,6 +5,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -49,12 +54,74 @@ public class WFSController extends HttpServlet {
 	@RequestMapping("**")
 	public void httpHandler(HttpServletRequest hsreq, HttpServletResponse hsres) {
 		try {
+			
 			PrintWriter wr = hsres.getWriter();
-			String request = hsreq.getParameter("REQUEST");
+			List<String> paramNames = new LinkedList<String>();
+			Enumeration<String> paramNamesE = hsreq.getParameterNames();
+			while(paramNamesE.hasMoreElements()) paramNames.add(paramNamesE.nextElement());
+			
+			// Prepare parameters
+			String request = null;
+			String version = null;
+			String service = null;
+			
+			/* Look for parameter names to assign values
+			 * in order to avoid casing issues with parameter names (such as a mismatch between reQUEST and request and REQUEST).
+			 */
+			
+			for(String paramName : paramNames) {
+				if(paramName.equalsIgnoreCase("REQUEST")) {
+					request = hsreq.getParameter(paramName);
+				}
+				
+				if(paramName.equalsIgnoreCase("VERSION")) {
+					version = hsreq.getParameter(paramName);
+				}
+				
+				
+				if(paramName.equalsIgnoreCase("SERVICE")) {
+					service = hsreq.getParameter(paramName);
+				}
+			}
+			
+			// The SERVICE parameter is required. If not specified, is an error (throw exception through XML).
+			if(service != null) {
+
+				// For the WFS servlet it must be WFS
+				if(!service.equalsIgnoreCase("WFS")) {
+					hsres.sendError(HttpServletResponse.SC_NOT_FOUND);
+					return;
+				}
+				
+			}
+			
+			else {
+				WFSExceptionWriter owsExcept = new WFSExceptionWriter("WFS server error. SERVICE parameter is required.", "request", "MissingParameterValue", hsres);
+				owsExcept.write();
+				return;
+			}
+			
+			// The VERSION parameter is required for all operations EXCEPT GetCapabilities §7.6.25 of WFS 2.0 Interface Standard
+			if(request != null){
+				
+				// Only go through version checks if NOT a Get Capabilities request
+				if(!request.equalsIgnoreCase(WFSRequestType.GetCapabilities.toString())) {
+				
+					if(version != null ) {
+						
+					}
+			
+					else {
+						WFSExceptionWriter owsExcept = new WFSExceptionWriter("WFS server error. VERSION parameter is required.", "request", "MissingParameterValue", hsres);
+						owsExcept.write();
+						return;
+					}
+				}
+			}
 			
 			// The REQUEST Parameter is required. If not specified, is an error (throw exception through XML).
 			if(request != null) {
-				if(request.equals(WFSRequestType.GetCapabilities.toString())) {
+				if(request.equalsIgnoreCase(WFSRequestType.GetCapabilities.toString())) {
 					getCapabilities(wr, hsreq);
 				}
 			}

--- a/tds/src/main/java/thredds/server/wfs/WFSExceptionWriter.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSExceptionWriter.java
@@ -5,6 +5,12 @@ import java.io.PrintWriter;
 
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * A simple XML writer for XML-based WFS exceptions.
+ * 
+ * @author wchen@usgs.gov
+ *
+ */
 public class WFSExceptionWriter {
 	private final String text;
 	private final String ExceptionCode;

--- a/tds/src/main/java/thredds/server/wfs/WFSExceptionWriter.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSExceptionWriter.java
@@ -15,14 +15,14 @@ public class WFSExceptionWriter {
 	private final String text;
 	private final String ExceptionCode;
 	private final String locator;
-	private final HttpServletResponse hsr;
 	
 	/**
 	 * Given the information on construction, writes the necessary exception information.
 	 * 
+	 * @param hsr the Servlet Response to write to
 	 * @throws IOException
 	 */
-	public void write() throws IOException{
+	public void write(HttpServletResponse hsr) throws IOException{
 		PrintWriter xmlResponse = hsr.getWriter();
 		
 		xmlResponse.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
@@ -47,10 +47,9 @@ public class WFSExceptionWriter {
 	 * @param ExceptionCode the standardized exception code
 	 * @param hsr http response to write to
 	 */
-	public WFSExceptionWriter(String text, String locator, String ExceptionCode, HttpServletResponse hsr) {
+	public WFSExceptionWriter(String text, String locator, String ExceptionCode) {
 		this.text = text;
 		this.locator = locator;
 		this.ExceptionCode = ExceptionCode;
-		this.hsr = hsr;
 	}
 }

--- a/tds/src/main/java/thredds/server/wfs/WFSExceptionWriter.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSExceptionWriter.java
@@ -29,7 +29,9 @@ public class WFSExceptionWriter {
 		xmlResponse.append("<ows:ExceptionReport xml:lang=\"en-US\" xsi:schemaLocation=\"http://www.opengis.net/ows/1.1"
 				+ " http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd\" version=\"2.0.0\" xmlns:ows=\"http://www.opengis.net/ows/1.1\""
 				+ " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">");
-		xmlResponse.append("<ows:Exception locator=\"" + locator + "\" exceptionCode=\"" + ExceptionCode + "\">");
+		xmlResponse.append("<ows:Exception ");
+		if(locator != null) xmlResponse.append("locator=\"" + locator + "\" ");
+		xmlResponse.append("exceptionCode=\"" + ExceptionCode + "\">");
 		xmlResponse.append("<ows:ExceptionText>" + text + "</ows:ExceptionText>");
 		xmlResponse.append("</ows:Exception>");
 		xmlResponse.append("</ows:ExceptionReport>");
@@ -37,6 +39,8 @@ public class WFSExceptionWriter {
 	
 	/**
 	 * Creates a new OWS Exception Report based on a text and an exception code.
+	 * 
+	 * Some exceptions do not specify locators. For these exceptions send in null for the locator.
 	 * 
 	 * @param text the text associated with the exception
 	 * @param locator the locator associated with the exception

--- a/tds/src/main/java/thredds/server/wfs/WFSGetFeatureWriter.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSGetFeatureWriter.java
@@ -1,0 +1,49 @@
+package thredds.server.wfs;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * A writer for a WFS compliant Feature Collection GML file.
+ * Answers to GetFeature requests.
+ * 
+ * @author wchen@usgs.gov
+ *
+ */
+public class WFSGetFeatureWriter {
+	
+	private PrintWriter response;
+	private String fileOutput;
+	
+	/**
+	 * Initiate the response with an XML file with an XML header and the FeatureCollection tag.
+	 */
+	public void startXML() {
+		fileOutput += "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+		fileOutput += "<wfs:FeatureCollection xsi:schemaLocation=\"http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+				+ " xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:gml=\"http://opengis.net/gml\" xmlns:fes=\"http://www.opengis.net/fes/2.0\" xmlns:ogc=\"http://www.opengis.net/ogc\""
+				+ " xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:wfs=\"http://opengis.net/wfs/2.0\" xmlns=\"http://www.opengis.net/wfs/2.0\" version=\"2.0.0\">";
+	}
+	
+	/**
+	 * Finish writing the XML file, write the end tag for FeatureCollection and append it all to the PrintWriter.
+	 * 
+	 * Once a XML is finished, the WFSDataWriter is no longer usable.
+	 */
+	public void finishXML() {
+		fileOutput += "</wfs:FeatureCollection>";
+		response.append(fileOutput);
+		fileOutput = null; response = null;
+	}
+	
+	/**
+	 * Opens a WFSGetFeatureWriter, writes to the response given.
+	 * 
+	 * @param response to write to
+	 * @throws IOException 
+	 */
+	public WFSGetFeatureWriter(PrintWriter response) {
+		this.fileOutput = "";
+		this.response = response;
+	}
+}

--- a/tds/src/main/java/thredds/server/wfs/WFSRequestType.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSRequestType.java
@@ -28,4 +28,18 @@ public enum WFSRequestType {
 	{
 		return this.number;
 	}
+	
+	/**
+	 * Converts a string to a WFSRequestType if possible.
+	 * 
+	 * @param request value
+	 * @return the string as a WFSRequestType if possible.
+	 */
+	public static WFSRequestType getWFSRequestType(String request) {
+		if(request == null) return null;
+		if(request.equalsIgnoreCase(WFSRequestType.GetCapabilities.toString())) return WFSRequestType.GetCapabilities;
+		if(request.equalsIgnoreCase(WFSRequestType.GetFeature.toString())) return WFSRequestType.GetFeature;
+		if(request.equalsIgnoreCase(WFSRequestType.DescribeFeatureType.toString())) return WFSRequestType.DescribeFeatureType;
+		else return null;
+	}
 }


### PR DESCRIPTION
In this pull request:
* The WFS Web Service becomes an official THREDDS Web Service and it works correctly through THREDDS Catalog Web Service Access. In order to enable it add this service declaration to the catalog.xml:

`<service name="wfs" serviceType="WFS" base="/thredds/wfs/" />`

* The WFS Web Service no longer enforces all upper case parameter names or values. Any mix of casing (such as rEqUEST) is now accepted.

* The WFS Web Service now enforces the SERVICE and VERSION parameters. SERVICE requires value WFS and VERSION requires 2, 2.0, or 2.0.0, 2.0.2... etc. Of course, the values are not case sensitive.

* Enforcement of valid values for REQUEST as well (GetCapabilities DescribeFeature and GetFeature).