### PR TITLE
Map 104 / 108 - Actual GetFeature Request

### DIFF
--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/adapter/SimpleGeometryCSBuilder.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/adapter/SimpleGeometryCSBuilder.java
@@ -67,7 +67,7 @@ public class SimpleGeometryCSBuilder {
   private SimpleGeometryReader geometryReader;
   private ProjectionImpl orgProj;
 
-  SimpleGeometryCSBuilder(NetcdfDataset ds, CoordinateSystem cs, Formatter errlog) {
+  public SimpleGeometryCSBuilder(NetcdfDataset ds, CoordinateSystem cs, Formatter errlog) {
 
     // must be at least 2 dimensions
     if (cs.getRankDomain() < 2) {

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/adapter/SimpleGeometryCSBuilder.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/adapter/SimpleGeometryCSBuilder.java
@@ -5,7 +5,9 @@
 package ucar.nc2.ft2.coverage.adapter;
 
 import ucar.nc2.Dimension;
+import ucar.nc2.Variable;
 import ucar.nc2.constants.AxisType;
+import ucar.nc2.constants.CF;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dataset.*;
 import ucar.nc2.ft2.coverage.simpgeometry.GeometryType;
@@ -64,9 +66,12 @@ public class SimpleGeometryCSBuilder {
   private List<CoordinateAxis> sgAxes;
   private List<CoordinateTransform> coordTransforms;
   private List<Dimension> dims;
+  private List<String> geometrySeriesVarNames;
+  private List<String> geometryContainerNames;
   private SimpleGeometryReader geometryReader;
+  private Map<String, List<String>> geometryContainersAssoc;
   private ProjectionImpl orgProj;
-
+  
   public SimpleGeometryCSBuilder(NetcdfDataset ds, CoordinateSystem cs, Formatter errlog) {
 
     // must be at least 2 dimensions
@@ -76,8 +81,38 @@ public class SimpleGeometryCSBuilder {
     }
     
     sgAxes = new ArrayList<CoordinateAxis>();
+    geometrySeriesVarNames = new ArrayList<String>();
+    geometryContainerNames = new ArrayList<String>();
+    geometryContainersAssoc = new HashMap<String, List<String>>();
     dims = ds.getDimensions();
     allAxes = cs.getCoordinateAxes();
+    
+    // Look through the variables and build a list of geometry variables, also build up map of simple geometry containers 
+    for(Variable var : ds.getVariables()) {
+    	if(!var.findAttValueIgnoreCase(CF.GEOMETRY, "").equals("")) {
+    		
+    		geometrySeriesVarNames.add(var.getFullNameEscaped());
+    		String varName = var.findAttValueIgnoreCase(CF.GEOMETRY, "");
+    		
+    		// Using the Geometry Container name, add this variable as a reference to that container
+    		
+    		// Check if container exists
+    		if(ds.findVariable(varName) != null) {
+    		
+    			// Add container name to container name list, if not present already
+    			if(!geometryContainerNames.contains(varName)) geometryContainerNames.add(varName);
+    			
+    			// If the list is null, instantiate it
+    			if(geometryContainersAssoc.get(varName) == null) {
+    				List<String> strList = new ArrayList<String>();
+    				geometryContainersAssoc.put(varName, strList);
+    			}
+    		
+    			// Then add this variable as a reference.
+    			geometryContainersAssoc.get(var.findAttValueIgnoreCase(CF.GEOMETRY, "")).add(var.getFullNameEscaped());
+    		}
+    	}
+    }
     
     // Create Simple Geometry Reader if there are any Axes with type SimpleGeometryID
     // Also, populate simple geometry axis list 
@@ -111,9 +146,6 @@ public class SimpleGeometryCSBuilder {
     return null;
   }
 
-  public FeatureType getCoverageType() {
-    return type;
-  }
   
   /**
    * Returns the list of all axes contained in this coordinate system.
@@ -265,6 +297,37 @@ public class SimpleGeometryCSBuilder {
 	  
 	  return ptList;
   }
+  
+  /**
+   * Returns the names of variables which are detected
+   * as geometry containers.
+   * 
+   * @return variable name
+   */
+  public List<String> getGeometryContainerNames(){
+	  return this.geometryContainerNames;
+  }
+  
+  /**
+   * Returns the names of variables which are detected
+   * as geometry data series.
+   * 
+   * @return variable name
+   */
+  public List<String> getGeometrySeriesNames(){
+	  return this.geometrySeriesVarNames;
+  }
+  
+  /**
+   * Returns a list of variables (in no particular order)
+   * which utilize the given geometry container.
+   * 
+   * @param nameOfContainer to find associations for
+   * @return associations (if any) null if none
+   */
+  public List<String> getGeometryContainerAssociations(String nameOfContainer){
+	 return this.geometryContainersAssoc.get(nameOfContainer); 
+  }
 
   public SimpleGeometryCS makeCoordSys() {
     if (type == null) return null;
@@ -277,6 +340,15 @@ public class SimpleGeometryCSBuilder {
     }
   }
 
+  /**
+   * Returns the feature type of this type
+   * 
+   * @return
+   */
+  public FeatureType getCoverageType() {
+	  return this.type;
+  }
+  
   @Override
   public String toString() {
     Formatter f2 = new Formatter();

--- a/tds/src/main/java/thredds/server/wfs/GMLFeatureWriter.java
+++ b/tds/src/main/java/thredds/server/wfs/GMLFeatureWriter.java
@@ -75,7 +75,7 @@ public class GMLFeatureWriter {
 
         Polygon polygon = poly;
         
-        while (polygon != null) {
+    //    while (polygon != null) {
 
             if (!polygon.getInteriorRing()) {
                 xml += "<gml:exterior><gml:LinearRing><gml:posList>";
@@ -98,8 +98,8 @@ public class GMLFeatureWriter {
                 xml += "</gml:posList></gml:LinearRing></gml:interior>";
             }
 
-            polygon = polygon.getNext();
-        }
+      //      polygon = polygon.getNext();
+       // }
 
         xml += "</gml:Polygon>";
         return xml;

--- a/tds/src/main/java/thredds/server/wfs/WFSController.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSController.java
@@ -3,6 +3,9 @@ package thredds.server.wfs;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import thredds.core.DataRootManager;
+import thredds.core.DataRootManager.DataRootMatch;
+import thredds.server.catalog.DataRoot;
 import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.ft2.coverage.simpgeometry.SimpleGeometryFeatureDataset;
 
@@ -205,6 +208,20 @@ public class WFSController extends HttpServlet {
 			String version = null;
 			String service = null;
 			String typeNames = null;
+			String datasetReqPath = null;
+			String actualPath = null;
+			
+			if(hsreq.getServletPath().length() > 4) {
+				datasetReqPath = hsreq.getServletPath().substring(4, hsreq.getServletPath().length());
+			}
+			
+			DataRootMatch match = DataRootManager.getInstance().findDataRootMatch(datasetReqPath);
+			
+			if(match != null) {
+				actualPath = match.dataRoot.getPath();
+				hsres.getWriter().append(actualPath);
+				return;
+			}
 			
 			/* Look for parameter names to assign values
 			 * in order to avoid casing issues with parameter names (such as a mismatch between reQUEST and request and REQUEST).
@@ -261,7 +278,8 @@ public class WFSController extends HttpServlet {
 		}
 		
 		catch(IOException io) {
-			throw new RuntimeException("ERROR: retrieval of writer failed", io);
+			throw new RuntimeException("ERROR: An IOException has occurred. The writer may not have been able to been have retrieved"
+					+ " or the requested dataset was not found", io);
 		}
 	}
 }

--- a/tds/src/main/java/thredds/server/wfs/WFSController.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSController.java
@@ -247,8 +247,6 @@ public class WFSController extends HttpServlet {
 
 				}
 				
-				// Similarly go through a simple typenames check for non-existing feature types
-				//if(actualFTName == null) return new WFSExceptionWriter("Failed to retrieve feature data. The Feature Type specifed may not be valid for this dataset.", "GetFeature", "OperationProcessingFailed");
 			}
 			
 			WFSRequestType reqToProc = WFSRequestType.getWFSRequestType(request);

--- a/tds/src/main/java/thredds/server/wfs/WFSGetFeatureWriter.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSGetFeatureWriter.java
@@ -2,11 +2,8 @@ package thredds.server.wfs;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.List;
 
-import ucar.nc2.ft2.coverage.simpgeometry.CFPoint;
-import ucar.nc2.ft2.coverage.simpgeometry.Point;
 import ucar.nc2.ft2.coverage.simpgeometry.SimpleGeometry;
 
 /**
@@ -22,6 +19,7 @@ public class WFSGetFeatureWriter {
 	private String fileOutput;
 	private final String namespace;
 	private final String server;
+	private final String ftName;
 	private List<SimpleGeometry> geometries;
 	
 	/**
@@ -30,7 +28,7 @@ public class WFSGetFeatureWriter {
 	private void writeHeadersAndBB() {
 		fileOutput += "<wfs:FeatureCollection xsi:schemaLocation=" + WFSXMLHelper.encQuotes("http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd " + namespace + " " + server
 					+ "?request=DescribeFeatureType" + WFSXMLHelper.AMPERSAND + "service=wfs" + WFSXMLHelper.AMPERSAND + "version=2.0.0" + WFSXMLHelper.AMPERSAND + "typename=" 
-					+ WFSController.TDSNAMESPACE + "%3A" + "hru_soil_moist")
+					+ WFSController.TDSNAMESPACE + "%3A" + ftName)
 				+ " xmlns:xsi=" + WFSXMLHelper.encQuotes("http://www.w3.org/2001/XMLSchema-instance")
 				+ " xmlns:xlink=" + WFSXMLHelper.encQuotes("http://www.w3.org/1999/xlink")
 				+ " xmlns:gml=" + WFSXMLHelper.encQuotes("http://opengis.net/gml/3.2")
@@ -71,7 +69,7 @@ public class WFSGetFeatureWriter {
 				   += "<wfs:member>"
 					
 					// Write Geometry Information
-					+ "<" + WFSController.TDSNAMESPACE + ":hru_soil_moist gml:id=\"hru_soil_moist." + index + "\">"
+					+ "<" + WFSController.TDSNAMESPACE + ":" + ftName + " gml:id=\"" + ftName + "." + index + "\">"
 					
 					// GML Bounding Box
 					+ "<gml:boundedBy>"
@@ -89,7 +87,7 @@ public class WFSGetFeatureWriter {
 			// Cap off headers
 			fileOutput
 					+="</" + WFSController.TDSNAMESPACE + ":catchments_geometry_container>"
-					+ "</" + WFSController.TDSNAMESPACE + ":hru_soil_moist>"
+					+ "</" + WFSController.TDSNAMESPACE + ":" + ftName +">"
 					+ "</wfs:member>";
 			
 			index++;
@@ -115,11 +113,12 @@ public class WFSGetFeatureWriter {
 	 * @param namespace WFS TDS Namespace URI
 	 * @throws IOException 
 	 */
-	public WFSGetFeatureWriter(PrintWriter response, String server, String namespace, List<SimpleGeometry> geometries) {
+	public WFSGetFeatureWriter(PrintWriter response, String server, String namespace, List<SimpleGeometry> geometries, String ftName) {
 		this.fileOutput = "";
 		this.response = response;
 		this.server = server;
 		this.namespace = namespace;
 		this.geometries = geometries;
+		this.ftName = ftName;
 	}
 }


### PR DESCRIPTION
In this pull request:

* GetFeature and GetCapabilities is actually implemented most of the way! This, however, means that launching a GetFeature request on /thredds/wfs/ and/or a non-existing dataset no longer works... This is because GetFeature (and GetCapabilities) now determine Feature Types based on the specified dataset (and will fetch and write geospatial data from those datasets)!

* So a couple of things will require implementing in the future those being: proper bounding boxes (have to zoom in a lot right now), and handling edge cases with TYPENAMES/TYPENAME.

* Line and Point do test data do not currently render in QGIS as of now. DescribeFeatureType must be made to change according to dataset as well in order for this to work.

* The HRU Soil Moist Dataset _will_ render in QGIS, provided the URL includes the correct dataset.

* The WFS Geometry Element is named "catchments_geometry_container"- this could probably change to just "geometry" instead.