### PR TITLE
MAP-104 - Bounding Boxes and Checks

### DIFF
--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/simpgeometry/CFLine.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/simpgeometry/CFLine.java
@@ -283,6 +283,64 @@ public class CFLine implements Line {
 	}
 	
 	/**
+	 * Gets the upper bounding box coordinate on the line.
+	 * @return double array = (x, y)
+	 */
+	public double[] getBBUpper() {
+		double[] bbUpper = new double[2];
+		
+		List<Point> ptList = this.getPoints();
+		if(ptList.isEmpty()) return null;
+		bbUpper[0] = ptList.get(0).getY();
+		bbUpper[1] = ptList.get(0).getY();
+		
+		for(Point pt : this.getPoints()) {
+			if(bbUpper[0] < pt.getX()){
+				bbUpper[0] = pt.getX();
+			}
+			
+			if(bbUpper[1] < pt.getY()) {
+				bbUpper[1] = pt.getY();
+			}
+		}
+		
+		// Got maximum points, add some padding.
+		bbUpper[0] += 10;
+		bbUpper[1] += 10;
+		
+		return bbUpper;
+	}
+	
+	/**
+	 * Gets the lower bounding box coordinate on the line.
+	 * @return double array = (x, y)
+	 */
+	public double[] getBBLower() {
+		double[] bbLower = new double[2];
+		
+		List<Point> ptList = this.getPoints();
+		if(ptList.isEmpty()) return null;
+		bbLower[0] = ptList.get(0).getY();
+		bbLower[1] = ptList.get(0).getY();
+		
+		for(Point pt : this.getPoints()) {
+			if(bbLower[0] > pt.getX()){
+				bbLower[0] = pt.getX();
+			}
+			
+			if(bbLower[1] > pt.getY()) {
+				bbLower[1] = pt.getY();
+			}
+		}
+		
+		// Got minimum points, add some padding.
+		bbLower[0] -= 10;
+		bbLower[1] -= 10;
+		
+		return bbLower;
+	}
+	
+	/**
 	 *  Constructs an "empty" line with no members using an ArrayList to implement the point list.
 	 * 
 	 */

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/simpgeometry/CFPoint.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/simpgeometry/CFPoint.java
@@ -232,6 +232,24 @@ public class CFPoint implements Point{
 	}
 	
 	/**
+	 * Gets the upper bounding box coordinate on the point.
+	 * @return double array = (x, y)
+	 */
+	public double[] getBBUpper() {
+		double[] bbUpper = { this.getX() + 10, this.getY() + 10 };
+		return bbUpper;
+	}
+	
+	/**
+	 * Gets the lower bounding box coordinate on the polygon.
+	 * @return double array = (x, y)
+	 */
+	public double[] getBBLower() {
+		double[] bbLower = { this.getX() - 10, this.getY() - 10 };
+		return bbLower;
+	}
+	
+	/**
 	 * Construct a new point from specified parameters
 	 * The construction will automatically connect in related parts of a Multipoint - just specify any constituents
 	 * of a multipoint as next or prev.

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/simpgeometry/CFPolygon.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/simpgeometry/CFPolygon.java
@@ -329,6 +329,63 @@ public class CFPolygon implements Polygon  {
 		return this;
 	}
 	
+	/**
+	 * Gets the upper bounding box coordinate on the polygon.
+	 * @return double array = (x, y)
+	 */
+	public double[] getBBUpper() {
+		double[] bbUpper = new double[2];
+		
+		List<Point> ptList = this.getPoints();
+		if(ptList.isEmpty()) return null;
+		bbUpper[0] = ptList.get(0).getY();
+		bbUpper[1] = ptList.get(0).getY();
+		
+		for(Point pt : this.getPoints()) {
+			if(bbUpper[0] < pt.getX()){
+				bbUpper[0] = pt.getX();
+			}
+			
+			if(bbUpper[1] < pt.getY()) {
+				bbUpper[1] = pt.getY();
+			}
+		}
+		
+		// Got maximum points, add some padding.
+		bbUpper[0] += 10;
+		bbUpper[1] += 10;
+		
+		return bbUpper;
+	}
+	
+	/**
+	 * Gets the lower bounding box coordinate on the polygon.
+	 * @return double array = (x, y)
+	 */
+	public double[] getBBLower() {
+		double[] bbLower = new double[2];
+		
+		List<Point> ptList = this.getPoints();
+		if(ptList.isEmpty()) return null;
+		bbLower[0] = ptList.get(0).getY();
+		bbLower[1] = ptList.get(0).getY();
+		
+		for(Point pt : this.getPoints()) {
+			if(bbLower[0] > pt.getX()){
+				bbLower[0] = pt.getX();
+			}
+			
+			if(bbLower[1] > pt.getY()) {
+				bbLower[1] = pt.getY();
+			}
+		}
+		
+		// Got minimum points, add some padding.
+		bbLower[0] -= 10;
+		bbLower[1] -= 10;
+		
+		return bbLower;
+	}
 	
 	/**
 	 * Constructs an empty polygon with nothing in it using an Array List.

--- a/cdm/src/main/java/ucar/nc2/ft2/coverage/simpgeometry/SimpleGeometry.java
+++ b/cdm/src/main/java/ucar/nc2/ft2/coverage/simpgeometry/SimpleGeometry.java
@@ -18,4 +18,6 @@ public interface SimpleGeometry {
     public void setData(Array data);
     public Array getData();
 
+    public double[] getBBLower();
+    public double[] getBBUpper();
 }

--- a/tds/src/main/java/thredds/server/wfs/WFSController.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSController.java
@@ -73,11 +73,11 @@ public class WFSController extends HttpServlet {
 		gcdw.finishXML();
 	}
 
-	private void describeFeatureType(PrintWriter out, HttpServletRequest hsreq) {
+	private void describeFeatureType(PrintWriter out, HttpServletRequest hsreq, String ftName) {
 		WFSDescribeFeatureTypeWriter dftw = new WFSDescribeFeatureTypeWriter(out, WFSController.constructServerPath(hsreq), WFSController.getXMLNamespaceXMLNSValue(hsreq));
 		dftw.startXML();
 		ArrayList<WFSFeatureAttribute> attributes = new ArrayList<>();
-		attributes.add(new WFSFeatureAttribute("catchments_geometry_container", "gml:SurfaceArrayPropertyType"));
+		attributes.add(new WFSFeatureAttribute("geometryInformation", "gml:SurfaceArrayPropertyType"));
 		attributes.add(new WFSFeatureAttribute("hruid", "int"));
 		attributes.add(new WFSFeatureAttribute("lat", "double"));
 		attributes.add(new WFSFeatureAttribute("lon", "double"));
@@ -85,7 +85,7 @@ public class WFSController extends HttpServlet {
 		attributes.add(new WFSFeatureAttribute("catchments_perimeter", "double"));
 		attributes.add(new WFSFeatureAttribute("catchments_veght", "double"));
 		attributes.add(new WFSFeatureAttribute("catchments_cov", "double"));
-		dftw.addFeature(new WFSFeature("hru_soil_moist", "hru_soil_moistType", "AbstractFeatureType",attributes));
+		dftw.addFeature(new WFSFeature(ftName, ftName + "Type", "AbstractFeatureType",attributes));
 		dftw.writeFeatures();
 		dftw.finishXML();
 	}
@@ -338,7 +338,7 @@ public class WFSController extends HttpServlet {
 					break;
 					
 					case DescribeFeatureType:
-						describeFeatureType(wr, hsreq);
+						describeFeatureType(wr, hsreq, actualFTName);
 						
 					break;
 					

--- a/tds/src/main/java/thredds/server/wfs/WFSController.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSController.java
@@ -96,27 +96,26 @@ public class WFSController extends HttpServlet {
 	 * @param out
 	 * @return
 	 */
-	private void getFeature(PrintWriter out, HttpServletRequest hsreq, SimpleGeometryCSBuilder sgcs, String ftName) {
+	private WFSExceptionWriter getFeature(PrintWriter out, HttpServletRequest hsreq, SimpleGeometryCSBuilder sgcs, String ftName, String fullFtName) {
 		
 		List<SimpleGeometry> geometryList = new ArrayList<SimpleGeometry>();
 		
 		GeometryType geoT = sgcs.getGeometryType(ftName);
 		
-		switch(geoT) {
+		if(geoT == null){
+			return new WFSExceptionWriter("Feature Type of " + fullFtName + " not found.", "GetFeature" , "OperationProcessingFailed");
+		}
+		
+		try {
+		
+			switch(geoT) {
 			case POINT:
 				Point pt = sgcs.getPoint(ftName, 0);
 				int j = 0;
 				while(pt != null) {
 					geometryList.add(pt);
 					j++;
-					try {
-						pt = sgcs.getPoint(ftName, j);
-					}
-					
-					// Perhaps will change this to be implemented in the CFPolygon class
-					catch(ArrayIndexOutOfBoundsException aout) {
-						break;
-					}
+					pt = sgcs.getPoint(ftName, j);
 				}
 				break;
 				
@@ -127,14 +126,7 @@ public class WFSController extends HttpServlet {
 				while(line != null) {
 					geometryList.add(line);
 					k++;
-					try {
-						line = sgcs.getLine(ftName, k);
-					}
-					
-					// Perhaps will change this to be implemented in the CFPolygon class
-					catch(ArrayIndexOutOfBoundsException aout) {
-						break;
-					}
+					line = sgcs.getLine(ftName, k);
 				}	
 				
 				break;
@@ -146,17 +138,17 @@ public class WFSController extends HttpServlet {
 				while(poly != null) {
 					geometryList.add(poly);
 					i++;
-					try {
-						poly = sgcs.getPolygon(ftName, i);
-					}
-					
-					// Perhaps will change this to be implemented in the CFPolygon class
-					catch(ArrayIndexOutOfBoundsException aout) {
-						break;
-					}
+					poly = sgcs.getPolygon(ftName, i);
 				}
 				
 				break;
+			
+			}
+		}
+		
+		// Perhaps will change this to be implemented in the CFPolygon class
+		catch(ArrayIndexOutOfBoundsException aout){
+			
 		}
 
 
@@ -164,6 +156,8 @@ public class WFSController extends HttpServlet {
 		gfdw.startXML();
 		gfdw.writeMembers();
 		gfdw.finishXML();
+		
+		return null;
 	}
 	
 	/**
@@ -176,7 +170,7 @@ public class WFSController extends HttpServlet {
 	 * @param actualFTName parameter value
 	 * @return an ExceptionWriter if any errors occurred or null if none occurred
 	 */
-	private WFSExceptionWriter checkParametersForError(String request, String version, String service, String actualFTName) {
+	private WFSExceptionWriter checkParametersForError(String request, String version, String service, String typeName) {
 		// The SERVICE parameter is required. If not specified, is an error (throw exception through XML).
 		if(service != null) {
 			// For the WFS servlet it must be WFS if not, write out an InvalidParameterValue exception.
@@ -243,6 +237,10 @@ public class WFSController extends HttpServlet {
 
 				}
 				
+				// Last check to see if typenames is specified, must be for GetFeature, DescribeFeatureType
+				if(typeName == null) {
+					return new WFSExceptionWriter("WFS server error. For the specifed request, parameter typename or typenames must be specified.", request, "MissingParameterValue");
+				}
 			}
 			
 			WFSRequestType reqToProc = WFSRequestType.getWFSRequestType(request);
@@ -326,8 +324,8 @@ public class WFSController extends HttpServlet {
 				}
 			}
 			
-			WFSExceptionWriter paramError = checkParametersForError(request, version, service, actualFTName);
-			
+			WFSExceptionWriter paramError = checkParametersForError(request, version, service, typeNames);
+			WFSExceptionWriter requestProcessingError = null;
 			
 			// If parameter checks all pass launch the request
 			if(paramError == null) {
@@ -345,7 +343,7 @@ public class WFSController extends HttpServlet {
 					break;
 					
 					case GetFeature:
-						getFeature(wr, hsreq, cs, actualFTName);
+						requestProcessingError = getFeature(wr, hsreq, cs, actualFTName, typeNames);
 					break;
 				}	
 				
@@ -356,10 +354,18 @@ public class WFSController extends HttpServlet {
 				paramError.write(hsres);
 				return;
 			}
+			
+			/* Specifically writes out exceptions that were incurred
+			 * while processing requests.
+			 */
+			if(requestProcessingError != null){
+				requestProcessingError.write(hsres);
+				return;
+			}
 		}
 		
-		catch(IOException io) {
-			throw new RuntimeException("ERROR: An IOException has occurred. The writer may not have been able to been have retrieved"
+		catch(IOException io) {	
+			throw new RuntimeException("The writer may not have been able to been have retrieved"
 					+ " or the requested dataset was not found", io);
 		}
 	}

--- a/tds/src/main/java/thredds/server/wfs/WFSGetFeatureWriter.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSGetFeatureWriter.java
@@ -116,14 +116,14 @@ public class WFSGetFeatureWriter {
 					+ "</gml:Envelope>"
 					+ "</gml:boundedBy>"
 					
-					+ "<" + WFSController.TDSNAMESPACE + ":catchments_geometry_container>";
+					+ "<" + WFSController.TDSNAMESPACE + ":geometryInformation>";
 
 			//write GML features
 			fileOutput += writer.writeFeature(geometryItem);
 					
 			// Cap off headers
 			fileOutput
-					+="</" + WFSController.TDSNAMESPACE + ":catchments_geometry_container>"
+					+="</" + WFSController.TDSNAMESPACE + ":geometryInformation>"
 					+ "</" + WFSController.TDSNAMESPACE + ":" + ftName +">"
 					+ "</wfs:member>";
 			


### PR DESCRIPTION
This is an improvement update to the original MAP-104 PR. It contains the following:
* Proper Bounding Boxes are supported for GetFeature and makes it a lot easier to find the geometry in WFS Clients. Just Zoom to Layer to zoom directly to the feature. It has not been updated yet for GetCapabilities, however.
* Checks on the Typename parameter are now present. It is required for both DescribeFeatureType and GetFeature, and if it refers to a non-existent feature type, a WFSException is emitted, as well (instead of null pointering).
* Just updated: Geometry Container renamed and allowed feature type to pass through DescribeFeatureType allowing any point/line/polygon dataset feature to be drawn.